### PR TITLE
Update AlphaSatColorMatrixEvaluator.java

### DIFF
--- a/app/src/main/java/rnr/tests/imageloadingpattern/AlphaSatColorMatrixEvaluator.java
+++ b/app/src/main/java/rnr/tests/imageloadingpattern/AlphaSatColorMatrixEvaluator.java
@@ -22,7 +22,8 @@ public class AlphaSatColorMatrixEvaluator implements TypeEvaluator {
 
         // Compute the alpha change over period [0, 2]
         float alpha = Math.min(phase, 2f) / 2f;
-        elements [19] = (float)Math.round(alpha * 255);
+        //elements [19] = (float)Math.round(alpha * 255);
+        elements [18] = alpha;
 
         // We substract to make the picture look darker, it will automatically clamp
         // This is spread over period [0, 2.5]


### PR DESCRIPTION
Fixed issue when performing this animation on images which have transparency. Without this fix, the transparent regions in the image appear as black. 
See http://stackoverflow.com/questions/27262022/how-to-implement-loading-images-pattern-opacity-exposure-and-saturation-fro/31938452#31938452 for full details.
